### PR TITLE
Remove errant print output which polutes log file

### DIFF
--- a/ipf/glue2/computing_share_accel_info.py
+++ b/ipf/glue2/computing_share_accel_info.py
@@ -157,7 +157,6 @@ class ComputingShareAcceleratorInfoOgfJson(EntityOgfJson):
         if self.data.UsedAcceleratorSlots is not None:
             doc["UsedAcceleratorSlots"] = self.data.UsedAcceleratorSlots
 
-        print self.data.ComputingShareID
         if len(self.data.ComputingShareID) > 0:
             doc["Associations"]={}
             doc["Associations"]["ComputingShareID"] = self.data.ComputingShareID


### PR DESCRIPTION
Minor polution of log for compute workflow when logging is changed from DEBUG (default) to WARNING or ERROR only.